### PR TITLE
Enhance menu navigation with left/right arrow sibling switching

### DIFF
--- a/components/display/menu_state_machine.c
+++ b/components/display/menu_state_machine.c
@@ -144,24 +144,22 @@ bool menu_state_process_event(input_event_e event, unsigned char ch)
 
     case INPUT_EVENT_RIGHT_ARROW:
     case INPUT_EVENT_LEFT_ARROW:
-        if (s_menu_context.current_menu->handle_input_key)
+        if (s_menu_context.menu_active)
         {
-            // Leaf items handle left/right for their own internal navigation
-            s_menu_context.current_menu->handle_input_key(s_menu_context.current_menu->user_ctx, event, ch);
-        }
-        else if (s_menu_context.menu_active && s_menu_context.current_menu->parent)
-        {
-            // Switch focus between sibling menus (with wrap-around), same as encoder CW/CCW
-            if (event == INPUT_EVENT_RIGHT_ARROW) {
-                menu_focus_next_child(s_menu_context.current_menu->parent);
-            } else {
-                menu_focus_prev_child(s_menu_context.current_menu->parent);
+            if (s_menu_context.current_menu->handle_input_key)
+            {
+                // Leaf items handle left/right for their own internal navigation
+                s_menu_context.current_menu->handle_input_key(s_menu_context.current_menu->user_ctx, event, ch);
             }
-        }
-        else if (!s_menu_context.menu_active)
-        {
-            // If not active, return to root
-            menu_navigate_to(s_menu_context.root_menu);
+            else
+            {
+                // Switch focus between sibling menus (with wrap-around), same as encoder CW/CCW
+                if (event == INPUT_EVENT_RIGHT_ARROW) {
+                    menu_focus_next_child(s_menu_context.current_menu);
+                } else {
+                    menu_focus_prev_child(s_menu_context.current_menu);
+                }
+            }
         }
         event_consumed = true;
         break;

--- a/components/display/menu_state_machine.c
+++ b/components/display/menu_state_machine.c
@@ -142,11 +142,34 @@ bool menu_state_process_event(input_event_e event, unsigned char ch)
         event_consumed = true;
         break;
 
+    case INPUT_EVENT_RIGHT_ARROW:
+    case INPUT_EVENT_LEFT_ARROW:
+        if (s_menu_context.current_menu->handle_input_key)
+        {
+            // Leaf items handle left/right for their own internal navigation
+            s_menu_context.current_menu->handle_input_key(s_menu_context.current_menu->user_ctx, event, ch);
+        }
+        else if (s_menu_context.current_menu->parent)
+        {
+            // Navigate between sibling menus (with wrap-around)
+            struct menu_item *sibling = (event == INPUT_EVENT_RIGHT_ARROW)
+                ? menu_get_next_sibling(s_menu_context.current_menu)
+                : menu_get_prev_sibling(s_menu_context.current_menu);
+            if (!sibling) {
+                sibling = (event == INPUT_EVENT_RIGHT_ARROW)
+                    ? menu_get_first_child(s_menu_context.current_menu->parent)
+                    : menu_get_last_child(s_menu_context.current_menu->parent);
+            }
+            if (sibling) {
+                menu_navigate_to(sibling);
+            }
+        }
+        event_consumed = true;
+        break;
+
     case INPUT_EVENT_KEYCODE:
     case INPUT_EVENT_BACKSPACE:
     case INPUT_EVENT_TAB:
-    case INPUT_EVENT_RIGHT_ARROW:
-    case INPUT_EVENT_LEFT_ARROW:
     case INPUT_EVENT_DOWN_ARROW:
     case INPUT_EVENT_UP_ARROW:
         if (s_menu_context.current_menu->handle_input_key)

--- a/components/display/menu_state_machine.c
+++ b/components/display/menu_state_machine.c
@@ -149,20 +149,19 @@ bool menu_state_process_event(input_event_e event, unsigned char ch)
             // Leaf items handle left/right for their own internal navigation
             s_menu_context.current_menu->handle_input_key(s_menu_context.current_menu->user_ctx, event, ch);
         }
-        else if (s_menu_context.current_menu->parent)
+        else if (s_menu_context.menu_active && s_menu_context.current_menu->parent)
         {
-            // Navigate between sibling menus (with wrap-around)
-            struct menu_item *sibling = (event == INPUT_EVENT_RIGHT_ARROW)
-                ? menu_get_next_sibling(s_menu_context.current_menu)
-                : menu_get_prev_sibling(s_menu_context.current_menu);
-            if (!sibling) {
-                sibling = (event == INPUT_EVENT_RIGHT_ARROW)
-                    ? menu_get_first_child(s_menu_context.current_menu->parent)
-                    : menu_get_last_child(s_menu_context.current_menu->parent);
+            // Switch focus between sibling menus (with wrap-around), same as encoder CW/CCW
+            if (event == INPUT_EVENT_RIGHT_ARROW) {
+                menu_focus_next_child(s_menu_context.current_menu->parent);
+            } else {
+                menu_focus_prev_child(s_menu_context.current_menu->parent);
             }
-            if (sibling) {
-                menu_navigate_to(sibling);
-            }
+        }
+        else if (!s_menu_context.menu_active)
+        {
+            // If not active, return to root
+            menu_navigate_to(s_menu_context.root_menu);
         }
         event_consumed = true;
         break;


### PR DESCRIPTION
Allow users to switch between same-level menus using left and right arrow keys in the menu interface.

**Changes:**
- LEFT arrow → navigate to previous sibling menu (with wrap-around)
- RIGHT arrow → navigate to next sibling menu (with wrap-around)
- Leaf items with their own input handlers continue to receive left/right events for internal navigation
- Nonleaf menus without explicit handlers benefit from the new sibling navigation

**Example:** In the Bluetooth menu, pressing RIGHT switches to WiFi menu; pressing LEFT switches to Keyboard Mode menu.